### PR TITLE
Add commandline usage and fix segfault in failure to open a file

### DIFF
--- a/src/commandargs.cpp
+++ b/src/commandargs.cpp
@@ -5,15 +5,26 @@
 
 static ProgramConfiguration* Config = nullptr;
 static Setting* CurrentState = nullptr;
+String programName;
 
 bool MatchesFlag(String token)
 {
+	if(token.length() < 1)
+	{
+		return false;
+	}
+
     for(Setting& s: *Config)
     {
         if(token == s.Flag)
         {
             CurrentState = &s;
             return true;
+        }
+        else if(token.at(0) == '-')
+        {
+        	// If an unknown which resembles a flag is passed, inform the user
+        	Usage(std::vector<SettingOption>());
         }
     }
     return false;
@@ -23,6 +34,8 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config)
 {
     Config = &config;
     CurrentState = nullptr;
+    bool inFlag = false;
+    programName = "./program.pebl";
 
     std::vector<SettingOption> CurrentSettingOptions;
     CurrentSettingOptions.reserve(8);
@@ -34,11 +47,20 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config)
         {
             CurrentState->Action(CurrentSettingOptions);
             CurrentSettingOptions.clear();
+            inFlag = true;
+        }
+        else if(inFlag)
+        {
+        	// Flags consume one argument
+            SettingOption option = arg;
+            CurrentSettingOptions.push_back(option);
+            inFlag = false;
         }
         else
         {
-            SettingOption option = arg;
-            CurrentSettingOptions.push_back(option);
+			// Set program name to run
+			programName = argv[i];
+			break;
         }
     }
 

--- a/src/commandargs.h
+++ b/src/commandargs.h
@@ -19,4 +19,8 @@ typedef std::vector<Setting> ProgramConfiguration;
 
 void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config);
 
+void Usage(std::vector<SettingOption> options);
+
+extern String programName;
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     LogIt(LogSeverityType::Sev1_Notify, "main", "program compile begins");
 
     auto prog = ParseProgram(programName);
-    if(FatalCompileError)
+    if(FatalCompileError || prog == nullptr)
         return 1;
 
     LogIt(LogSeverityType::Sev1_Notify, "main", "program compile finished");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,13 @@
 #include "execute.h"
 #include "commandargs.h"
 
+void Usage(std::vector<SettingOption> options)
+{
+	// If this was derived at build time, that would be fantastic
+    std::cerr << "Usage: pebble [--help] [--log sev0|sev1|sev2|sev3] [program.pebl]" << std::endl;
+
+    exit(2);
+}
 
 void ChangeLogType(std::vector<SettingOption> options)
 {
@@ -37,9 +44,12 @@ void ChangeLogType(std::vector<SettingOption> options)
 
 ProgramConfiguration Config
 {
-    { 
+    {
         "Log Setting", "--log", ChangeLogType
-    }
+    },
+    {
+   		"Usage", "--help", Usage
+    },
 };
 
 
@@ -52,7 +62,7 @@ int main(int argc, char* argv[])
 {
     ParseCommandArgs(argc, argv, Config);
 
-    bool ShouldPrintInitialCompileResult = true; 
+    bool ShouldPrintInitialCompileResult = true;
     bool ShouldPrintProgramExecutionFinalResult = true;
 
     PurgeLog();                         // cleans log between each run
@@ -62,7 +72,7 @@ int main(int argc, char* argv[])
     // compile program
     LogIt(LogSeverityType::Sev1_Notify, "main", "program compile begins");
 
-    auto prog = ParseProgram("./program.pebl");
+    auto prog = ParseProgram(programName);
     if(FatalCompileError)
         return 1;
 
@@ -85,7 +95,7 @@ int main(int argc, char* argv[])
     LogIt(LogSeverityType::Sev1_Notify, "main", "program execution begins");
 
     DoProgram(prog);
-    
+
     LogIt(LogSeverityType::Sev1_Notify, "main", "program execution finished");
     SetConsoleColor(ConsoleColor::LightBlue);
     std::cout << "################################################################################\n";

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -141,7 +141,7 @@ String RemoveCommas(String line)
             continue;
         returnString += line.at(i);
     }
-    
+
     return returnString;
 }
 
@@ -174,7 +174,7 @@ String DecideTabString(String line)
 
     for(size_t i =0; i < line.size() && IsTabCharacter(line.at(i)); i++)
         tabString += line.at(i);
-    
+
     return tabString;
 }
 
@@ -340,7 +340,7 @@ void NumberOperation(Operation* op, int lineNumber)
     }
 }
 
-// can use this if every plays 
+// can use this if every plays
 typedef Operation*(*LineTypeFunctions)(PossibleOperationsList&, TokenList&);
 LineTypeFunctions lineFunctions[] = {ParseOutAtomic, ParseComposite};
 
@@ -352,7 +352,7 @@ Operation* ParseLine(TokenList& tokens)
 
     LineType lineType;
     DecideLineType(typeProbabilities, tokens, lineType);
-    
+
     // fPtr
     switch(lineType)
     {
@@ -378,7 +378,7 @@ int SizeOfBlock(std::vector<CodeLine>::iterator it, std::vector<CodeLine>::itera
 {
     int blockLevel = it->Level;
     int blockSize = 0;
-    for(; it != end && it->Level >= blockLevel; it++) 
+    for(; it != end && it->Level >= blockLevel; it++)
         blockSize++;
 
     return blockSize;
@@ -429,12 +429,12 @@ void HandleDefineMethod(
 }
 
 Block* ParseBlock(
-    std::vector<CodeLine>::iterator it, 
+    std::vector<CodeLine>::iterator it,
     std::vector<CodeLine>::iterator end,
     Scope* scope)
 {
     Block* thisBlock = BlockConstructor();
-    
+
     LogItDebug("entered new block", "ParseBlock");
     bool scopeIsLocal = false;
 
@@ -498,6 +498,7 @@ Program* ParseProgram(const std::string filepath)
     if(!file.is_open())
     {
         std::cout << "\ncould not open file: " << filepath << std::endl;
+        return nullptr;
     }
 
     int lineLevel = 0;


### PR DESCRIPTION
As per title.

Hopefully didn't introduce any new memory leaks ☺. 

An ideal solution for commandline arguments/usage would be one that is generated at runtime or so, but this would require a commandline parsing infrastructure that includes self-specifying usage text for each flag and extraneous information for each tag as well. 

Something like:

```shell
$ socketh -h
Usage of socketh:
  -mc uint
    	Set the max number of connections. (default 30)
  -p string
    	Set the port to listen on. (default ":9090")
$ 
```