### PR TITLE
Commandline redux

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: make TestBuilder
       run: make TestBuilder
-    - name: make pebble_textbuild.exe
+    - name: make pebble_testbuild.exe
       run: make pebble_testbuild.exe
     - name: run pebble_testbuild.exe
       run: ./pebble_testbuild.exe --ignore-custom --bytecode

--- a/assets/test_main.cpp
+++ b/assets/test_main.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
-#include <string>
+#include <ctime>
+#include <chrono>
+#include <ratio>
 
 #include "main.h"
 #include "program.h"
@@ -8,25 +10,42 @@
 #include "operation.h"
 #include "reference.h"
 #include "parse.h"
+#include "execute.h"
 #include "commandargs.h"
+#include "vm.h"
+#include "flattener.h"
+#include "scope.h"
 
-void SettingIgnoreCustom(std::vector<SettingOption> options)
+bool Usage(std::vector<SettingOption> options)
+{
+    std::cerr << "Usage pebble: [--help] [--ignore-custom] [--noisy] [--bytecode] [program.pebl]" << std::endl;
+
+    exit(2);
+}
+
+bool SettingIgnoreCustom(std::vector<SettingOption> options)
 {
     g_shouldRunCustomProgram = false;
+    return false;
 }
 
-void SettingNoisy(std::vector<SettingOption> options)
+bool SettingNoisy(std::vector<SettingOption> options)
 {
     g_noisyReport = true;
+    return false;
 }
 
-void SettingUseBytecodeRuntime(std::vector<SettingOption> options)
+bool SettingUseBytecodeRuntime(std::vector<SettingOption> options)
 {
     g_useBytecodeRuntime = true;
+    return false;
 }
 
 ProgramConfiguration Config
 {
+    {
+        "Pebl File", "program.pebl", nullptr
+    },
     { 
         "Ignore ./program.pebl", "--ignore-custom", SettingIgnoreCustom
     },
@@ -45,7 +64,7 @@ bool g_useBytecodeRuntime = false;
 
 int main(int argc, char *argv[])
 {
-    ParseCommandArgs(argc, argv, Config);
+    ParseCommandArgs(argc, argv, &Config);
     
     bool testsFailed = Test();
     if(testsFailed)

--- a/src/commandargs.cpp
+++ b/src/commandargs.cpp
@@ -8,21 +8,35 @@ static Setting* CurrentState = nullptr;
 
 bool MatchesFlag(String token, Setting** matchedSetting)
 {
+	if(token.length() < 1)
+	{
+		return false;
+	}
+
     for(Setting& s: *Config)
     {
         if(token == s.Flag)
         {
+        	CurrentState = &s;
             *matchedSetting = &s;
             return true;
         }
     }
+    
+    // If an unknown which resembles a flag is passed, inform the user
+    if(token.at(0) == '-')
+    {
+        Usage(std::vector<SettingOption>());
+    }
+    
     return false;
 }
 
-void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config)
+void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration* config)
 {
-    Config = &config;
+    Config = config;
     CurrentState = nullptr;
+    bool inFlag = false;
 
     std::vector<SettingOption> CurrentSettingOptions;
     CurrentSettingOptions.reserve(8);
@@ -30,20 +44,26 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config)
     for(int i=1; i<argc; i++)
     {
         String arg = argv[i];
+        
         Setting* newSetting = nullptr;
         if(MatchesFlag(arg, &newSetting))
-        {
-            if(CurrentState != nullptr)
-            {
-                CurrentState->Action(CurrentSettingOptions);
-                CurrentSettingOptions.clear();
-            }
-            CurrentState = newSetting;
+        {            
+			CurrentState->Action(CurrentSettingOptions);
+			CurrentSettingOptions.clear();
+            inFlag = true;
         }
-        else
+        else if(inFlag)
         {
+            // Flags consume at most one argument
             SettingOption option = arg;
             CurrentSettingOptions.push_back(option);
+            inFlag = false;
+        }
+        else
+        {        	
+            // Set program name to run, this is the 0'th Setting
+            Config->at(0).Flag = arg;
+            break;
         }
     }
 

--- a/src/commandargs.cpp
+++ b/src/commandargs.cpp
@@ -6,9 +6,11 @@
 static ProgramConfiguration* Config = nullptr;
 static Setting* CurrentState = nullptr;
 
+// Returns true if a flag is matched
 bool MatchesFlag(String token, Setting** matchedSetting)
 {
-    if(token.length() < 1)
+	// If there is no text (shouldn't happen) OR this is not a flag, discard
+    if(token.length() < 1 || token.at(0) != '-')
     {
         return false;
     }
@@ -47,7 +49,7 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration* config)
         
         Setting* newSetting = nullptr;
         if(MatchesFlag(arg, &newSetting))
-        {            
+        {
             if(CurrentState->Action(CurrentSettingOptions))
             {
                 inFlag = true;

--- a/src/commandargs.cpp
+++ b/src/commandargs.cpp
@@ -8,16 +8,16 @@ static Setting* CurrentState = nullptr;
 
 bool MatchesFlag(String token, Setting** matchedSetting)
 {
-	if(token.length() < 1)
-	{
-		return false;
-	}
+    if(token.length() < 1)
+    {
+        return false;
+    }
 
     for(Setting& s: *Config)
     {
         if(token == s.Flag)
         {
-        	CurrentState = &s;
+            CurrentState = &s;
             *matchedSetting = &s;
             return true;
         }
@@ -48,12 +48,12 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration* config)
         Setting* newSetting = nullptr;
         if(MatchesFlag(arg, &newSetting))
         {            
-			if(CurrentState->Action(CurrentSettingOptions))
-			{
-				inFlag = true;
-			}
-				
-			CurrentSettingOptions.clear();
+            if(CurrentState->Action(CurrentSettingOptions))
+            {
+                inFlag = true;
+            }
+                
+            CurrentSettingOptions.clear();
         }
         else if(inFlag)
         {

--- a/src/commandargs.cpp
+++ b/src/commandargs.cpp
@@ -48,9 +48,12 @@ void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration* config)
         Setting* newSetting = nullptr;
         if(MatchesFlag(arg, &newSetting))
         {            
-			CurrentState->Action(CurrentSettingOptions);
+			if(CurrentState->Action(CurrentSettingOptions))
+			{
+				inFlag = true;
+			}
+				
 			CurrentSettingOptions.clear();
-            inFlag = true;
         }
         else if(inFlag)
         {

--- a/src/commandargs.h
+++ b/src/commandargs.h
@@ -6,17 +6,19 @@
 struct Setting;
 
 typedef String SettingOption;
-typedef void (*SettingMethod)(std::vector<SettingOption>);
+typedef bool (*SettingMethod)(std::vector<SettingOption>);
 
 struct Setting
 {
     String SettingName;
     String Flag;
-    SettingMethod Action;
+    SettingMethod Action;    // Returns true if a flag is consumed
 };
 
 typedef std::vector<Setting> ProgramConfiguration;
 
-void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration config);
+void ParseCommandArgs(int argc, char* argv[], ProgramConfiguration* config);
+
+bool Usage(std::vector<SettingOption> options);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@
 bool Usage(std::vector<SettingOption> options)
 {
     // If this was derived at build time, that would be fantastic
-	// TODO - generate from Settings table and use null flags as non-flag [] args
+    // TODO - generate from Settings table and use null flags as non-flag [] args
     std::cerr << "Usage pebble: [--help] [--log sev0|sev1|sev2|sev3] [program.pebl]" << std::endl;
 
     exit(2);
@@ -53,15 +53,15 @@ bool ChangeLogType(std::vector<SettingOption> options)
 
 ProgramConfiguration Config
 {
-	{
-		/* 
-			This is the .pebl file to ingest. 
-			The flag string will be filled retro-actively with the program name, if any. 
-			Must be the 0'th Setting. 
-			Note: making Flag a vector rather than string could allow multiple files/args
-		*/
-		"Pebl File", "program.pebl", nullptr
-	},
+    {
+        /* 
+            This is the .pebl file to ingest. 
+            The flag string will be filled retro-actively with the program name, if any. 
+            Must be the 0'th Setting. 
+            Note: making Flag a vector rather than string could allow multiple files/args
+        */
+        "Pebl File", "program.pebl", nullptr
+    },
     {
         "Usage", "--help", Usage
     },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,10 +16,19 @@
 #include "flattener.h"
 #include "scope.h"
 
-void ChangeLogType(std::vector<SettingOption> options)
+bool Usage(std::vector<SettingOption> options)
+{
+    // If this was derived at build time, that would be fantastic
+	// TODO - generate from Settings table and use null flags as non-flag [] args
+    std::cerr << "Usage pebble: [--help] [--log sev0|sev1|sev2|sev3] [program.pebl]" << std::endl;
+
+    exit(2);
+}
+
+bool ChangeLogType(std::vector<SettingOption> options)
 {
     if(options.size() < 1)
-        return;
+        return false;
 
     SettingOption option = options[0];
     if(option == "sev0")
@@ -38,15 +47,28 @@ void ChangeLogType(std::vector<SettingOption> options)
     {
         LogAtLevel = LogSeverityType::Sev3_Critical;
     }
+    
+    return true;
 }
 
 ProgramConfiguration Config
 {
+	{
+		/* 
+			This is the .pebl file to ingest. 
+			The flag string will be filled retro-actively with the program name, if any. 
+			Must be the 0'th Setting. 
+			Note: making Flag a vector rather than string could allow multiple files/args
+		*/
+		"Pebl File", "program.pebl", nullptr
+	},
+    {
+        "Usage", "--help", Usage
+    },
     { 
         "Log Setting", "--log", ChangeLogType
-    }
+    },
 };
-
 
 // Logging
 LogSeverityType LogAtLevel = LogSeverityType::Sev0_Debug;
@@ -57,7 +79,7 @@ bool g_useBytecodeRuntime = true;
 
 int main(int argc, char* argv[])
 {
-    ParseCommandArgs(argc, argv, Config);
+    ParseCommandArgs(argc, argv, &Config);
 
     bool ShouldPrintInitialCompileResult = true; 
     bool ShouldPrintProgramExecutionFinalResult = true;
@@ -69,8 +91,8 @@ int main(int argc, char* argv[])
     // compile program
     LogIt(LogSeverityType::Sev1_Notify, "main", "program compile begins");
 
-    auto prog = ParseProgram("./program.pebl");
-    if(FatalCompileError)
+    auto prog = ParseProgram(Config.at(0).Flag);
+    if(FatalCompileError || prog == nullptr)
         return 1;
 
     LogIt(LogSeverityType::Sev1_Notify, "main", "program compile finished");
@@ -139,3 +161,4 @@ int main(int argc, char* argv[])
     LogItDebug("end reached.", "main");
     return 0;
 }
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ bool Usage(std::vector<SettingOption> options)
 bool ChangeLogType(std::vector<SettingOption> options)
 {
     if(options.size() < 1)
-        return false;
+        return true;
 
     SettingOption option = options[0];
     if(option == "sev0")

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -498,6 +498,7 @@ Program* ParseProgram(const std::string filepath)
     if(!file.is_open())
     {
         std::cout << "\ncould not open file: " << filepath << std::endl;
+        return nullptr;
     }
 
     int lineLevel = 0;


### PR DESCRIPTION
Previously: https://github.com/ktvng/pebble/pull/13

This PR includes adding:

-  `Usage:` message
- Commandline flag parsing which allows for flags to consume an argument, or no argument
- A few minor pointer/safety fixes
- Signature change for the Action method to allow signalling whether a flag will be consumed or not, this could also be implemented inside a Setting, etc. if desired, but may be better suited to a different model for Config

Requests for change from #13 should be integrated here. 

I did not see a clear way to cleanly generate the Usage message so I did not place it in this commit. I think Config should be a struct or other formal data structure other than a typedef for a vector. 

If Config had named fields, we could have flags in one vector, non-flag arguments as a list, and a program name all embedded separately. I feel like the current way to get a program name to execute is a bit of a hack and sentinel value are bad, but this _is_ c++, so maybe it doesn't matter. 

A viable path for a generated Usage might be forward declaring Usage or Config and giving Usage a way to access Config and parse it for printing where Usage isn't referenced inside Config as with `--help`. 

