### PR TITLE
Update demo documentation

### DIFF
--- a/demo/demos/docs/demo10
+++ b/demo/demos/docs/demo10
@@ -8,7 +8,7 @@ Compile-time checking has not yet been fully
 implemented. 
 
 # Details
-If you’re confused about the terminology on scope/section, checkout out Demo #8 (what’s really happening) for a detailed explanation.
+If you’re confused about the terminology on scope/section, checkout out Demo #11 (what’s really happening) for a detailed explanation.
 
 Calls take on a type at their time of definition, and this type is enforced henceforth. 
 The keywords 'a'/'an' refer to the type of the subsequent Call, and allow types to 

--- a/demo/demos/docs/demo10
+++ b/demo/demos/docs/demo10
@@ -8,7 +8,7 @@ Compile-time checking has not yet been fully
 implemented. 
 
 # Details
-If you’re confused about the terminology on scope/section, checkout out Demo #11 (what’s really happening) for a detailed explanation.
+If you’re confused about the terminology on scope/section, checkout out Demo #8 (what’s really happening) for a detailed explanation.
 
 Calls take on a type at their time of definition, and this type is enforced henceforth. 
 The keywords 'a'/'an' refer to the type of the subsequent Call, and allow types to 

--- a/demo/demos/docs/demo5
+++ b/demo/demos/docs/demo5
@@ -4,7 +4,8 @@ Methods are defined with the ':' operator followed by an indent block. We are cu
 working to support curly-braces for use with lambda expressions!
 
 
-Parentheses are not required when the method takes a non-zero number of arguments
+Parentheses are not required when the method takes zero arguments.
+Parenthesis are required when the method takes a non-zero number of arguments. 
 
 # Definitions
 

--- a/demo/demos/docs/demo503
+++ b/demo/demos/docs/demo503
@@ -10,7 +10,7 @@ Line [3] does the same, with the 'self' keyword emphasizing that 'Lesser' is
 to exist in this local scope (that of ‘Order’).
 
 
-Line [12] returns 'self' which allows “packages” everything up into an “object” whose
+Line [12] returns 'self' which “packages” everything up into an “object” whose
 attributes are the local scope of ‘Order’. Both ‘Greater’ and ‘Lesser’ are 
 calls defined in this local scope, and so become attributes of the returned entity 
 of ‘Order’. 

--- a/demo/demos/docs/demo6
+++ b/demo/demos/docs/demo6
@@ -13,8 +13,8 @@ local scope and those in the scope of its parent object.
 # Details
 
 In the example, `Refuel`, `Drive`, and `Init` can be thought of as their own 'objects',
-with their own scope. Thus, the 'self' keyword will actually refer to their own 
-(local) scope. To refer to the scope of the object which calls them, 'caller is used'.
+with their own scope. Thus, the `self` keyword will refer to each object's respective 
+(local) scope. To refer to the scope of the object which calls them, 'caller' is used.
 
 
 By default, a Call is first resolved in the local scope (‘self’), and only then the caller’s scope (‘caller’).


### PR DESCRIPTION
Line 7 previously said that you dont need to put parenthesis when there are 1 or more arguments, which I think is incorrect, but I;m not positive.