### PR TITLE
Fix failing test

### DIFF
--- a/src/interpreter/vm.cpp
+++ b/src/interpreter/vm.cpp
@@ -270,6 +270,14 @@ void InitRuntime()
     ErrorFlag = false;
 
     InstructionReg = 0;
+
+    JumpStatusReg = 0;
+    LocalScopeIsDetachedReg = false;
+    LastResultReg = nullptr;
+    CmpReg = CmpRegDefaultValue;
+
+    ExtendedArg = 0;
+    ExtensionExp = 0; 
 }
 
 /// true if [ins] is not an Extend instruction and the exponent of the ExtendedArg


### PR DESCRIPTION
This fixes the failing test due to shuffling the test cases. This was happening because certain VM registers weren't being cleared between each run, leading to undefined behavior in a subsequent test.